### PR TITLE
Fix go build for Solaris and Illumos

### DIFF
--- a/dirent_portable.go
+++ b/dirent_portable.go
@@ -1,5 +1,5 @@
-//go:build appengine || (!linux && !darwin && !freebsd && !openbsd && !netbsd)
-// +build appengine !linux,!darwin,!freebsd,!openbsd,!netbsd
+//go:build appengine || solaris || (!linux && !darwin && !freebsd && !openbsd && !netbsd)
+// +build appengine solaris !linux,!darwin,!freebsd,!openbsd,!netbsd
 
 package fastwalk
 

--- a/dirent_unix.go
+++ b/dirent_unix.go
@@ -1,6 +1,7 @@
-//go:build (aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris) && !appengine
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
+//go:build (aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd) && !appengine && !solaris
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd
 // +build !appengine
+// +build !solaris
 
 package fastwalk
 

--- a/entry_filter_portable.go
+++ b/entry_filter_portable.go
@@ -1,5 +1,5 @@
-//go:build appengine || (!linux && !darwin && !freebsd && !openbsd && !netbsd && !windows)
-// +build appengine !linux,!darwin,!freebsd,!openbsd,!netbsd,!windows
+//go:build appengine || (!linux && !darwin && !freebsd && !openbsd && !netbsd && !windows && !solaris)
+// +build appengine !linux,!darwin,!freebsd,!openbsd,!netbsd,!windows,!solaris
 
 package fastwalk
 

--- a/fastwalk_portable.go
+++ b/fastwalk_portable.go
@@ -1,5 +1,5 @@
-//go:build appengine || (!linux && !darwin && !freebsd && !openbsd && !netbsd)
-// +build appengine !linux,!darwin,!freebsd,!openbsd,!netbsd
+//go:build appengine || solaris || (!linux && !darwin && !freebsd && !openbsd && !netbsd)
+// +build appengine solaris !linux,!darwin,!freebsd,!openbsd,!netbsd
 
 package fastwalk
 


### PR DESCRIPTION
The `DT_REG` etc. constants are not defined for Solaris or Illumos. In Go 1.22 it appears they are only available on:

```
darwin
dragonfly
freebsd
linux
netbsd
openbsd
```

(cf. `grep -R DT_REG /opt/ooce/go-1.22/src/cmd/vendor/golang.org/x/sys/unix/ | cut -d: -f1 | sort -u | cut -d/ -f12 | cut -d_ -f2 | sort -u
darwin`)

This PR switches Solaris and Illumos to use the portable version of your code. Since https://github.com/junegunn/fzf/commit/208e5563322436112bb263e69a72f89b41c7037e this library will be a dependency of `fzf`, which currently builds fine on Solaris OSes, but will break in the next release without a change in your library.

Thanks for your time in reviewing! :clinking_glasses: 