### PR TITLE
darwin: cleanup syscall code and use a fixed buffer for opendir

### DIFF
--- a/zsyscall_darwin_amd64.1_13.s
+++ b/zsyscall_darwin_amd64.1_13.s
@@ -20,9 +20,3 @@ TEXT libc_opendir_trampoline<>(SB),NOSPLIT,$0-0
 
 GLOBL	·libc_opendir_trampoline_addr(SB), RODATA, $8
 DATA	·libc_opendir_trampoline_addr(SB)/8, $libc_opendir_trampoline<>(SB)
-
-TEXT libc___getdirentries64_trampoline<>(SB),NOSPLIT,$0-0
-	JMP libc___getdirentries64(SB)
-
-GLOBL	·libc___getdirentries64_trampoline_addr(SB), RODATA, $8
-DATA	·libc___getdirentries64_trampoline_addr(SB)/8, $libc___getdirentries64_trampoline<>(SB)

--- a/zsyscall_darwin_arm64.1_13.s
+++ b/zsyscall_darwin_arm64.1_13.s
@@ -20,9 +20,3 @@ TEXT libc_opendir_trampoline<>(SB),NOSPLIT,$0-0
 
 GLOBL	·libc_opendir_trampoline_addr(SB), RODATA, $8
 DATA	·libc_opendir_trampoline_addr(SB)/8, $libc_opendir_trampoline<>(SB)
-
-TEXT libc___getdirentries64_trampoline<>(SB),NOSPLIT,$0-0
-	JMP libc___getdirentries64(SB)
-
-GLOBL	·libc___getdirentries64_trampoline_addr(SB), RODATA, $8
-DATA	·libc___getdirentries64_trampoline_addr(SB)/8, $libc___getdirentries64_trampoline<>(SB)


### PR DESCRIPTION
Remove unused syscall code and use a fixed buffer for opendir which saves us an alloc.