### PR TITLE
gh: update workflows and add test for macos arm64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
@@ -25,4 +25,4 @@ jobs:
     - name: Test Race
       run: go test -race ./...
     - name: Test Builds
-      run: make test_build
+      run: make test_build --jobs=4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: Test fastwalk on macOS
+name: Test fastwalk on macOS amd64
 
 on:
   push:
@@ -8,14 +8,14 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         go: [1.21, 1.22]
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -1,4 +1,4 @@
-name: Test fastwalk on Windows
+name: Test fastwalk on macOS arm64
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         go: [1.21, 1.22]
@@ -20,5 +20,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
+    - name: Test
+      run: go test ./...
     - name: Test Race
       run: go test -race ./...

--- a/fastwalk_test.go
+++ b/fastwalk_test.go
@@ -321,6 +321,9 @@ func maxPathLength(t testing.TB) (root string, pathMax int) {
 // Test that we can handle PATH_MAX. This is mostly for the Unix tests
 // where we pass a buffer to ReadDirect (often getdents64(2)).
 func TestFastWalk_LongPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test not needed on Windows")
+	}
 	root, pathMax := maxPathLength(t)
 	t.Log("PATH_MAX:", pathMax)
 


### PR DESCRIPTION
* Test fastwalk on macos amd64 and arm64.
* Update actions/checkout to use `fetch-depth: 1` (it was previously 0 which pulls the full history, which we don't need)
* Change Windows to only run the race detector test (since running both is slow and not very useful)