### PR TITLE
Fixup tests on 32-bit

### DIFF
--- a/fastwalk_test.go
+++ b/fastwalk_test.go
@@ -959,7 +959,7 @@ func TestSortModeString(t *testing.T) {
 		{fastwalk.SortDirsFirst, "DirsFirst"},
 		{fastwalk.SortFilesFirst, "FilesFirst"},
 		{100, "SortMode(100)"},
-		{math.MaxUint32, fmt.Sprintf("SortMode(%d)", math.MaxUint32)},
+		{math.MaxUint32, fmt.Sprintf("SortMode(%d)", uint32(math.MaxUint32))},
 	}
 	for _, test := range tests {
 		got := test.mode.String()


### PR DESCRIPTION
Tests on 32-bit fail with:

```
github.com/charlievieth/fastwalk/internal/dirent github.com/charlievieth/fastwalk/internal/fmtdirent
108s # github.com/charlievieth/fastwalk_test [github.com/charlievieth/fastwalk.test]
108s src/github.com/charlievieth/fastwalk/fastwalk_test.go:962:48: cannot use math.MaxUint32 (untyped int constant 4294967295) as int value in argument to fmt.Sprintf (overflows)
```