### PR TITLE
gh: test fastwalk on 32-bit (386) Linux

### DIFF
--- a/.github/workflows/linux_386.yaml
+++ b/.github/workflows/linux_386.yaml
@@ -1,0 +1,21 @@
+name: Test fastwalk on Linux 386 (32-bit)
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.23.x'
+      - name: Test 386
+        run: |
+          GOARCH=386 go env
+          GOARCH=386 go test


### PR DESCRIPTION
Prevents issues like https://github.com/charlievieth/fastwalk/pull/32 from occurring in the future.