### PR TITLE
internal/dirent: move arch dependent code to make codecov happy

### DIFF
--- a/internal/dirent/dirent.go
+++ b/internal/dirent/dirent.go
@@ -9,55 +9,6 @@ import (
 	"unsafe"
 )
 
-// readInt returns the size-bytes unsigned integer in native byte order at offset off.
-func readInt(b []byte, off, size uintptr) (u uint64, ok bool) {
-	if len(b) < int(off+size) {
-		return 0, false
-	}
-	if isBigEndian {
-		return readIntBE(b[off:], size), true
-	}
-	return readIntLE(b[off:], size), true
-}
-
-func readIntBE(b []byte, size uintptr) uint64 {
-	switch size {
-	case 1:
-		return uint64(b[0])
-	case 2:
-		_ = b[1] // bounds check hint to compiler; see golang.org/issue/14808
-		return uint64(b[1]) | uint64(b[0])<<8
-	case 4:
-		_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
-		return uint64(b[3]) | uint64(b[2])<<8 | uint64(b[1])<<16 | uint64(b[0])<<24
-	case 8:
-		_ = b[7] // bounds check hint to compiler; see golang.org/issue/14808
-		return uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
-			uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
-	default:
-		panic("syscall: readInt with unsupported size")
-	}
-}
-
-func readIntLE(b []byte, size uintptr) uint64 {
-	switch size {
-	case 1:
-		return uint64(b[0])
-	case 2:
-		_ = b[1] // bounds check hint to compiler; see golang.org/issue/14808
-		return uint64(b[0]) | uint64(b[1])<<8
-	case 4:
-		_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
-		return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24
-	case 8:
-		_ = b[7] // bounds check hint to compiler; see golang.org/issue/14808
-		return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
-			uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
-	default:
-		panic("syscall: readInt with unsupported size")
-	}
-}
-
 const InvalidMode = os.FileMode(1<<32 - 1)
 
 func Parse(buf []byte) (consumed int, name string, typ os.FileMode) {

--- a/internal/dirent/endian_big.go
+++ b/internal/dirent/endian_big.go
@@ -6,4 +6,30 @@
 
 package dirent
 
-const isBigEndian = true
+// readInt returns the size-bytes unsigned integer in native byte order at offset off.
+func readInt(b []byte, off, size uintptr) (uint64, bool) {
+	if len(b) < int(off+size) {
+		return 0, false
+	}
+	b = b[off:]
+	switch size {
+	case 1:
+		return uint64(b[0]), true
+	case 2:
+		_ = b[1] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[1]) | uint64(b[0])<<8, true
+	case 4:
+		_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[3]) | uint64(b[2])<<8 | uint64(b[1])<<16 | uint64(b[0])<<24, true
+	case 8:
+		_ = b[7] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
+			uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56, true
+	default:
+		// This case is impossible if the tests pass. Previously, we panicked
+		// here but for performance reasons (escape analysis) it's better to
+		// trigger a panic via an out-of-bounds reference.
+		_ = b[len(b)]
+		return 0, false
+	}
+}

--- a/internal/dirent/endian_little.go
+++ b/internal/dirent/endian_little.go
@@ -6,4 +6,30 @@
 
 package dirent
 
-const isBigEndian = false
+// readInt returns the size-bytes unsigned integer in native byte order at offset off.
+func readInt(b []byte, off, size uintptr) (uint64, bool) {
+	if len(b) < int(off+size) {
+		return 0, false
+	}
+	b = b[off:]
+	switch size {
+	case 1:
+		return uint64(b[0]), true
+	case 2:
+		_ = b[1] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[0]) | uint64(b[1])<<8, true
+	case 4:
+		_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24, true
+	case 8:
+		_ = b[7] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+			uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56, true
+	default:
+		// This case is impossible if the tests pass. Previously, we panicked
+		// here but for performance reasons (escape analysis) it's better to
+		// trigger a panic via an out-of-bounds reference.
+		_ = b[len(b)]
+		return 0, false
+	}
+}


### PR DESCRIPTION
This is a pointless commit that simply moves the arch specific readInt* functions to their respective build tagged files. The goal here is to make codecov report a faired value (I don't really care about this, but some do so here we are).