### PR TITLE
Add codecov config to ignore internal/dirent filees

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "internal/dirent/*.go"


### PR DESCRIPTION
The `internal/dirent` code is well tested (both here and in the Go standard library) but the coverage is poor, which dramatically affects the repos overall coverage score.