### PR TITLE
README: remove codecov link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Test fastwalk on macOS](https://github.com/charlievieth/fastwalk/actions/workflows/macos.yml/badge.svg)](https://github.com/charlievieth/fastwalk/actions/workflows/macos.yml)
 [![Test fastwalk on Linux](https://github.com/charlievieth/fastwalk/actions/workflows/linux.yml/badge.svg)](https://github.com/charlievieth/fastwalk/actions/workflows/linux.yml)
 [![Test fastwalk on Windows](https://github.com/charlievieth/fastwalk/actions/workflows/windows.yml/badge.svg)](https://github.com/charlievieth/fastwalk/actions/workflows/windows.yml)
-[![codecov](https://codecov.io/gh/charlievieth/fastwalk/graph/badge.svg?token=UM8Y01K14K)](https://codecov.io/gh/charlievieth/fastwalk)
 
 # fastwalk
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - "internal/dirent/*.go"


### PR DESCRIPTION
Remove codecov link since it reports a deceptively low coverage result. This library has generally excellent coverage but there are good portions of code that are only executed on some OSes (via `runtime.GOOS`) but since coverage tools can't tell that that code is not included it distorts the coverage results.