### PR TITLE
internal/dirent: fix tests on s390x

### DIFF
--- a/internal/dirent/dirent_test.go
+++ b/internal/dirent/dirent_test.go
@@ -2,51 +2,7 @@
 
 package dirent
 
-import (
-	"encoding/binary"
-	"fmt"
-	"math"
-	"math/rand"
-	"testing"
-)
-
-func TestReadInt(t *testing.T) {
-	for _, sz := range []int{1, 2, 4, 8} {
-		rr := rand.New(rand.NewSource(1))
-		t.Run(fmt.Sprintf("%d", sz), func(t *testing.T) {
-			var fn func() uint64
-			switch sz {
-			case 1:
-				fn = func() uint64 { return uint64(rr.Int63n(256)) }
-			case 2:
-				fn = func() uint64 { return uint64(rr.Int63n(math.MaxUint16)) }
-			case 4:
-				fn = func() uint64 { return uint64(rr.Int63n(math.MaxUint32)) }
-			case 8:
-				fn = func() uint64 { return uint64(rr.Uint64()) }
-			default:
-				t.Fatal("invalid size:", sz)
-			}
-			buf := make([]byte, 8)
-			fails := 0
-			for i := 0; i < 100; i++ {
-				want := fn()
-				binary.NativeEndian.PutUint64(buf[:], want)
-				got, ok := readInt(buf, 0, uintptr(sz))
-				if got != want || !ok {
-					fails++
-					t.Errorf("readInt(%q, 0, %d) = %d, %t; want: %d, %t", buf, sz, got, ok, want, true)
-				}
-				if fails >= 10 {
-					t.Fatal("too many errors:", fails)
-				}
-			}
-		})
-	}
-	if i, ok := readInt(nil, 1, 1); i != 0 || ok {
-		t.Errorf("readInt(nil, 1, 1) = %d, %t; want: %d, %t", i, ok, 0, false)
-	}
-}
+import "testing"
 
 func TestReadIntSize(t *testing.T) {
 	if i, ok := readInt(nil, 1, 1); i != 0 || ok {


### PR DESCRIPTION
This commit fixes tests on s390x (big-endian) by removing TestReadInt, which really only existed for code coverage.

Fixes #61