### PR TITLE
dirent: no longer cache the results of Stat and Info

### DIFF
--- a/dirent.go
+++ b/dirent.go
@@ -3,50 +3,25 @@ package fastwalk
 import (
 	"io/fs"
 	"os"
-	"sync"
-	"sync/atomic"
 	"syscall"
-	"unsafe"
 )
 
-type fileInfo struct {
-	once sync.Once
-	fs.FileInfo
-	err error
-}
-
-func loadFileInfo(pinfo **fileInfo) *fileInfo {
-	ptr := (*unsafe.Pointer)(unsafe.Pointer(pinfo))
-	fi := (*fileInfo)(atomic.LoadPointer(ptr))
-	if fi == nil {
-		fi = &fileInfo{}
-		if !atomic.CompareAndSwapPointer(
-			(*unsafe.Pointer)(unsafe.Pointer(pinfo)), // adrr
-			nil,                                      // old
-			unsafe.Pointer(fi),                       // new
-		) {
-			fi = (*fileInfo)(atomic.LoadPointer(ptr))
-		}
-	}
-	return fi
-}
-
-// StatDirEntry returns a [fs.FileInfo] describing the named file ([os.Stat]).
-// If de is a [fastwalk.DirEntry] its Stat method is used and the returned
-// FileInfo may be cached from a prior call to Stat. If a cached result is not
-// desired, users should just call [os.Stat] directly.
+// StatDirEntry returns a [fs.FileInfo] describing the named file. If de is a
+// [fastwalk.DirEntry] its Stat method is used. Otherwise, [os.Stat] is called
+// on the path. Therefore, de should be the DirEntry describing path.
 //
-// This is a helper function for calling Stat on the DirEntry passed to the
-// walkFn argument to [Walk].
+// Note: This function was added when fastwalk used to always cache the result
+// of DirEntry.Stat. Now that fastwalk no longer explicitly caches the result
+// of Stat this function is slightly less useful and is equivalent to the below
+// code:
 //
-// The path argument is only used if de is not of type [fastwalk.DirEntry].
-// Therefore, de should be the DirEntry describing path.
+//	if d, ok := de.(DirEntry); ok {
+//		return d.Stat()
+//	}
+//	return os.Stat(path)
 func StatDirEntry(path string, de fs.DirEntry) (fs.FileInfo, error) {
 	if de == nil {
 		return nil, &os.PathError{Op: "stat", Path: path, Err: syscall.EINVAL}
-	}
-	if de.Type()&os.ModeSymlink == 0 {
-		return de.Info()
 	}
 	if d, ok := de.(DirEntry); ok {
 		return d.Stat()

--- a/dirent_test.go
+++ b/dirent_test.go
@@ -6,8 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
-	"sync"
 	"testing"
 
 	"github.com/charlievieth/fastwalk"
@@ -75,91 +73,5 @@ func TestDirent(t *testing.T) {
 			t.Errorf("lstat mismatch\n got:\n%s\nwant:\n%s",
 				fastwalk.FormatFileInfo(got), fastwalk.FormatFileInfo(want))
 		}
-		fi, err := fileEnt.Info()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if fi != got {
-			t.Error("failed to return or cache FileInfo")
-		}
-		de := fileEnt.(fastwalk.DirEntry)
-		fi, err = de.Stat()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if fi != got {
-			t.Error("failed to use cached Info result for non-symlink")
-		}
-	})
-
-	t.Run("Parallel", func(t *testing.T) {
-		testParallel := func(t *testing.T, de fs.DirEntry, fn func() (fs.FileInfo, error)) {
-			numCPU := runtime.NumCPU()
-
-			infos := make([][]fs.FileInfo, numCPU)
-			for i := range infos {
-				infos[i] = make([]fs.FileInfo, 100)
-			}
-
-			// Start all the goroutines at the same time to
-			// maximise the chance of a race
-			start := make(chan struct{})
-			var wg, ready sync.WaitGroup
-			ready.Add(numCPU)
-			wg.Add(numCPU)
-			for i := 0; i < numCPU; i++ {
-				go func(fis []fs.FileInfo, de fs.DirEntry) {
-					defer wg.Done()
-					ready.Done()
-					<-start
-					for i := range fis {
-						fis[i], _ = de.Info()
-					}
-				}(infos[i], de)
-			}
-
-			ready.Wait()
-			close(start) // start all goroutines at once
-			wg.Wait()
-
-			first := infos[0][0]
-			if first == nil {
-				t.Fatal("failed to stat file:", de.Name())
-			}
-			for _, fis := range infos {
-				for _, fi := range fis {
-					if fi != first {
-						t.Errorf("Expected the same fs.FileInfo to always "+
-							"be returned got: %#v want: %#v", fi, first)
-					}
-				}
-			}
-		}
-
-		t.Run("File", func(t *testing.T) {
-			t.Run("Stat", func(t *testing.T) {
-				_, fileEnt := getDirEnts(t)
-				de := fileEnt.(fastwalk.DirEntry)
-				testParallel(t, de, de.Stat)
-			})
-			t.Run("Lstat", func(t *testing.T) {
-				_, fileEnt := getDirEnts(t)
-				de := fileEnt.(fastwalk.DirEntry)
-				testParallel(t, de, de.Info)
-			})
-		})
-
-		t.Run("Link", func(t *testing.T) {
-			t.Run("Stat", func(t *testing.T) {
-				linkEnt, _ := getDirEnts(t)
-				de := linkEnt.(fastwalk.DirEntry)
-				testParallel(t, de, de.Stat)
-			})
-			t.Run("Lstat", func(t *testing.T) {
-				linkEnt, _ := getDirEnts(t)
-				de := linkEnt.(fastwalk.DirEntry)
-				testParallel(t, de, de.Info)
-			})
-		})
 	})
 }

--- a/fastwalk.go
+++ b/fastwalk.go
@@ -325,7 +325,7 @@ func (c *Config) Copy() *Config {
 
 // A DirEntry extends the [fs.DirEntry] interface to add a Stat() method
 // that returns the result of calling [os.Stat] on the underlying file.
-// The results of Info() and Stat() are cached.
+// The result of Info() may be cached. The result of Stat() is never cached.
 //
 // The [fs.DirEntry] argument passed to the [fs.WalkDirFunc] by [Walk] is
 // always a DirEntry.
@@ -333,10 +333,8 @@ type DirEntry interface {
 	fs.DirEntry
 
 	// Stat returns the fs.FileInfo for the file or subdirectory described
-	// by the entry. The returned FileInfo may be from the time of the
-	// original directory read or from the time of the call to os.Stat.
-	// If the entry denotes a symbolic link, Stat reports the information
-	// about the target itself, not the link.
+	// by the entry. If the entry denotes a symbolic link, Stat reports the
+	// information about the target itself, not the link.
 	Stat() (fs.FileInfo, error)
 
 	// Depth returns the depth at which this entry was generated relative to the


### PR DESCRIPTION
This commit changes fastwalk.DirEntry to no longer cache the result of
calling the Stat and Info methods. This reduces memory usage by reducing
the size of the underlying DirEntry type and by saving an allocation in
the call to Stat/Info.

Benchmarks:

```
goos: darwin
goarch: arm64
cpu: Apple M4 Pro
                           │ base.10.txt │             new.10.txt             │
                           │   sec/op    │   sec/op     vs base               │
UnixDirentInfo/Serial-14     648.6n ± 2%   616.6n ± 1%  -4.92% (p=0.000 n=10)
UnixDirentInfo/Parallel-14   969.4n ± 0%   932.5n ± 0%  -3.81% (p=0.000 n=10)
geomean                      792.9n        758.3n       -4.37%

                           │ base.10.txt │             new.10.txt             │
                           │    B/op     │    B/op     vs base                │
UnixDirentInfo/Serial-14      384.0 ± 0%   336.0 ± 0%  -12.50% (p=0.000 n=10)
UnixDirentInfo/Parallel-14    384.0 ± 0%   336.0 ± 0%  -12.50% (p=0.000 n=10)
geomean                       384.0        336.0       -12.50%

                           │ base.10.txt │             new.10.txt             │
                           │  allocs/op  │ allocs/op   vs base                │
UnixDirentInfo/Serial-14      4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
UnixDirentInfo/Parallel-14    4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
geomean                       4.000        3.000       -25.00%
```

```
goos: linux
goarch: arm64
                          │ base.10.txt │             new.10.txt             │
                          │   sec/op    │   sec/op     vs base               │
UnixDirentInfo/Serial-4     425.3n ± 1%   394.3n ± 0%  -7.29% (p=0.000 n=10)
UnixDirentInfo/Parallel-4   248.0n ± 2%   229.8n ± 2%  -7.36% (p=0.000 n=10)
geomean                     324.8n        301.0n       -7.32%

                          │ base.10.txt │             new.10.txt             │
                          │    B/op     │    B/op     vs base                │
UnixDirentInfo/Serial-4      368.0 ± 0%   320.0 ± 0%  -13.04% (p=0.000 n=10)
UnixDirentInfo/Parallel-4    368.0 ± 0%   320.0 ± 0%  -13.04% (p=0.000 n=10)
geomean                      368.0        320.0       -13.04%

                          │ base.10.txt │             new.10.txt             │
                          │  allocs/op  │ allocs/op   vs base                │
UnixDirentInfo/Serial-4      4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
UnixDirentInfo/Parallel-4    4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
geomean                      4.000        3.000       -25.00%
```

```
goos: linux
goarch: amd64
cpu: AMD EPYC-Milan Processor
                          │ base.10.txt │             new.10.txt             │
                          │   sec/op    │   sec/op     vs base               │
UnixDirentInfo/Serial-4     2.235µ ± 1%   2.162µ ± 3%  -3.24% (p=0.001 n=10)
UnixDirentInfo/Parallel-4   732.7n ± 2%   695.9n ± 2%  -5.03% (p=0.000 n=10)
geomean                     1.280µ        1.227µ       -4.14%

                          │ base.10.txt │             new.10.txt             │
                          │    B/op     │    B/op     vs base                │
UnixDirentInfo/Serial-4      384.0 ± 0%   336.0 ± 0%  -12.50% (p=0.000 n=10)
UnixDirentInfo/Parallel-4    384.0 ± 0%   336.0 ± 0%  -12.50% (p=0.000 n=10)
geomean                      384.0        336.0       -12.50%

                          │ base.10.txt │             new.10.txt             │
                          │  allocs/op  │ allocs/op   vs base                │
UnixDirentInfo/Serial-4      4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
UnixDirentInfo/Parallel-4    4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
geomean                      4.000        3.000       -25.00%
```